### PR TITLE
Add property indicatorHop to control speed at which the gauge needle moves

### DIFF
--- a/contribution.xml
+++ b/contribution.xml
@@ -23,6 +23,7 @@
 		<property type="String" title="Title" id="title"/>
 		<property type="int" title="Start Value" id="startValue"/>
 		<property type="int" title="End Value" id="endValue"/>
+		<property type="float" title="Indicator Speed" id="indicatorHop" />
 		<property type="boolean" title="Gradient Color" id="gradientColor"/>
 		<property type="Color" title="First Color" id="firstColor"/>
 		<property type="Color" title="Second Color" id="secondColor"/>
@@ -46,6 +47,7 @@
 			<defaultValue property="showValue">false</defaultValue>
 			<defaultValue property="startValue">0</defaultValue>
 			<defaultValue property="endValue">100</defaultValue>
+			<defaultValue property="indicatorHop">0.5</defaultValue>
 			<defaultValue property="gredientColor">true</defaultValue>
 			<defaultValue property="firstColor">#FA1E1E</defaultValue>
 			<defaultValue property="secondColor">#FCFA4E</defaultValue>

--- a/res/js/component.js
+++ b/res/js/component.js
@@ -9,6 +9,7 @@ sap.designstudio.sdk.Component.subclass("com.ac.speedometer.Speedometer", functi
 	var needleColor = "#D80000";
 	var startValue = 0;
 	var endValue = 100;
+	var indicatorHop = 0.5;
 	var title = "Insert Title Here";
 	var showedValue = "No Value";
 	var gradientColor = true;
@@ -133,6 +134,15 @@ sap.designstudio.sdk.Component.subclass("com.ac.speedometer.Speedometer", functi
 			return this;
 		}
 	};	
+	
+	this.indicatorHop = function(value) {
+		if (value == undefined) {
+			return indicatorHop;
+		} else {
+			indicatorHop = value;
+			return this;
+		}
+	};
 	
 	this.showedValue = function(value) {
 		if (value == undefined) {
@@ -496,6 +506,7 @@ if(!gradientColor){
 		}
 		
 		var currentIndicator = 0.5;
+		var maxIndicator = indicator*240/100
 
 		var ctx = that.sCanvas.getContext("2d");
 		ctx.translate(centerX, centerY);
@@ -512,7 +523,12 @@ if(!gradientColor){
 			ctx.shadowBlur = shadowOffsetBlur;
 			ctx.shadowColor = shadowColor;
 		
-			ctx.rotate(0.5  * DEG2RAD);
+			var nextValue = currentIndicator + indicatorHop;
+			var thisHop = indicatorHop;
+			if(nextValue > maxIndicator) {
+				thisHop = indicatorHop - (nextValue - maxIndicator);
+			}
+			ctx.rotate(thisHop  * DEG2RAD);
 			ctx.strokeStyle = needleColor;
 			ctx.lineWidth = secondHandWidth;
 			ctx.beginPath();
@@ -543,11 +559,11 @@ if(!gradientColor){
 			ctx.restore();
 		
 
-			if(currentIndicator>=(indicator*240/100)){
+			if(currentIndicator>=(maxIndicator)){
 				myStopFunction();
+			} else {
+				currentIndicator+=thisHop;
 			}
-			currentIndicator+=0.5;
-
 		}
 	}
 	


### PR DESCRIPTION
I've added an 'indicatorHop' property which controls the speed at which the needle moves around the gauge. Defaults to 0.5 (which was the value before). Also added a check to prevent the needle from going beyond the value it's meant to represent, which could happen now.